### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ We introduce a new benchmark to rigorously evaluate geometry prediction models o
 ### 📦 Installation
 
 ```bash
+conda create -n da3 python=3.12
+pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cu128
+
 pip install -e . # Basic
 pip install -e ".[gs]" # Gaussians Estimation and Rendering
 pip install -e ".[app]" # Gradio, python>=3.10

--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ We introduce a new benchmark to rigorously evaluate geometry prediction models o
 ### 📦 Installation
 
 ```bash
-conda create -n da3 python=3.12
-pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cu128
-
+pip install torch\>=2 torchvision
 pip install -e . # Basic
 pip install -e ".[gs]" # Gaussians Estimation and Rendering
 pip install -e ".[app]" # Gradio, python>=3.10


### PR DESCRIPTION
Thank you for your awesome work! haotong

`xformers` and `gsplat` try to import torch during compilation, so it is recommended to install torch before starting to install DA3.

```sh
  × Getting requirements to build wheel did not run successfully.
...
      ModuleNotFoundError: No module named 'torch'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'xformers' when getting requirements to build wheel
```

```sh
Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  ...
        File "<string>", line 135, in <module>
        File "<string>", line 33, in get_extensions
      ModuleNotFoundError: No module named 'torch'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'gsplat' when getting requirements to build wheel
```