### PR TITLE
Simple fix for MPS support

### DIFF
--- a/src/depth_anything_3/model/utils/head_utils.py
+++ b/src/depth_anything_3/model/utils/head_utils.py
@@ -132,7 +132,7 @@ def make_sincos_pos_embed(embed_dim: int, pos: torch.Tensor, omega_0: float = 10
     - emb: The generated 1D positional embedding.
     """
     assert embed_dim % 2 == 0
-    omega = torch.arange(embed_dim // 2, dtype=torch.double, device=pos.device)
+    omega = torch.arange(embed_dim // 2, dtype=torch.float32, device=pos.device)
     omega /= embed_dim / 2.0
     omega = 1.0 / omega_0**omega  # (D/2,)
 


### PR DESCRIPTION
# Fix: Use float32 dtype in make_sincos_pos_embed for MPS compatibility

This PR changes the line

```
omega = torch.arange(embed_dim // 2, dtype=torch.double, device=pos.device)
```
to
```
omega = torch.arange(embed_dim // 2, dtype=torch.float32, device=pos.device)
```

# Motivation

Apple’s MPS backend does not fully support float64, which causes failures when tensors are created with that dtype. The positional-embedding function was implicitly producing float64, which prevents the model from running on M1/M2/M3 GPUs.

Using float32 resolves the issue and keeps the code consistent with the rest of the model, which already operates in float32.

# Impact

The functional behavior of the positional embeddings remains unchanged for all practical purposes.

The change improves:
- proper execution on Apple Silicon (no MPS dtype errors),
- consistent precision across the codebase.

No other parts of the pipeline are affected.

# Tested

Verified on macOS with MPS that the model runs end-to-end without dtype errors.
CPU and CUDA paths continue to work as before.