### PR TITLE
contiguous before reshape to keep conv input contiguous

### DIFF
--- a/src/depth_anything_3/model/dpt.py
+++ b/src/depth_anything_3/model/dpt.py
@@ -217,7 +217,8 @@ class DPT(nn.Module):
         for stage_idx, take_idx in enumerate(self.intermediate_layer_idx):
             x = feats[take_idx][:, patch_start_idx:]  # [B*S, N_patch, C]
             x = self.norm(x)
-            x = x.permute(0, 2, 1).reshape(B, C, ph, pw)  # [B*S, C, ph, pw]
+            # permute -> contiguous before reshape to keep conv input contiguous
+            x = x.permute(0, 2, 1).contiguous().reshape(B, C, ph, pw)  # [B*S, C, ph, pw]
 
             x = self.projects[stage_idx](x)
             if self.pos_embed:


### PR DESCRIPTION
Made the permute output contiguous before reshaping. 
Prevents PyTorch from viewing a non‑contiguous tensor which caused the .view error when running on MacOS.

```
  File "../venv3.11/lib/python3.11/site-packages/torch/nn/modules/conv.py", line 543, in _conv_forward
    return F.conv2d(
           ^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
