### PR TITLE
Fix typo in api docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -105,7 +105,7 @@ The main API class that provides depth estimation capabilities with optional pos
 #### 🎯 Initialization
 
 ```python
-from depth_anything_3 import DepthAnything3
+from depth_anything_3.api import DepthAnything3
 
 # Initialize the model with a model name
 model = DepthAnything3(model_name="da3-large")


### PR DESCRIPTION
Thanks for the awesome work!

As mentioned in PR #36, using `from depth_anything_3 import DepthAnything3` will cause an import error.  
The previous PR fixed the typo in the **Usage Examples** section, but the same typo in the **Core API** section was missed.

This minor PR addresses that remaining issue.
