### PR TITLE
Add rel_depth and metric_depth evaluation modes

### DIFF
--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -151,6 +151,10 @@ workspace/benchmark_dataset/
 | `pose` | Camera pose estimation | AUC@3°, AUC@30° |
 | `recon_unposed` | 3D reconstruction with **predicted** poses | F-score, Overall |
 | `recon_posed` | 3D reconstruction with **GT** poses | F-score, Overall |
+| `rel_depth` | **Relative depth** (scale/affine-invariant) | Abs Rel, δ@1.03/1.25 |
+| `metric_depth` | **Metric depth** (no alignment) | Abs Rel, δ@1.03/1.25, metric scale error/rel |
+
+Depth modes write JSON files to `metric_results/{dataset}_{mode}.json`. They reuse the unposed inference export (`.../unposed/exports/mini_npz/results.npz`).
 
 ### Basic Usage
 

--- a/src/depth_anything_3/bench/configs/eval_bench.yaml
+++ b/src/depth_anything_3/bench/configs/eval_bench.yaml
@@ -34,7 +34,8 @@ eval:
     - dtu64
 
   # Evaluation modes
-  # Options: pose, recon_unposed, recon_posed, view_syn
+  # Options: pose, recon_unposed, recon_posed, view_syn, rel_depth, metric_depth
+  # modes: [pose, recon_unposed, recon_posed, rel_depth, metric_depth]
   modes:
     - pose
     - recon_unposed
@@ -95,4 +96,3 @@ presets:
     datasets: [eth3d]
     modes: [pose, recon_unposed]
     scenes: [courtyard]
-

--- a/src/depth_anything_3/bench/depth_metrics.py
+++ b/src/depth_anything_3/bench/depth_metrics.py
@@ -1,0 +1,241 @@
+"""depth_anything_3.bench.depth_metrics
+
+Depth / inverse-depth quality metrics used by the VGB (Visual Geometry Benchmark).
+
+This module is intended to back the two new evaluator modes:
+
+* **metric_depth**: evaluate *metric* depth quality directly in meters (no alignment).
+* **rel_depth**: evaluate *relative* depth quality by removing global scale and/or
+  affine ambiguity (scale or scale+shift), then scoring the aligned predictions.
+
+Why both?
+
+* Multi-view systems often produce depth that is *accurate up to a global scale*
+  (or sometimes scale+shift, depending on representation).
+* Systems claiming *metric depth* should also be measured without any alignment,
+  and their *scale accuracy* should be reported separately ("Metric Scale rel"),
+  because a method can have good relative depth but poor absolute scale.
+
+Metric definitions (per-pixel on valid GT depth):
+
+* **abs_rel**:
+    mean( |d̂ - d| / d )
+  This matches the "Reld" (relative depth error) used in MoGe-2/MapAnything.
+* **delta@t**:
+    100 * mean( max(d̂/d, d/d̂) < t )
+  This matches the δ depth inlier metric used in many depth benchmarks and in
+  MoGe-2 / moge_eval (t=1.25 by default there). MapAnything additionally reports
+  a tighter threshold around t=1.03 ("Depth inliers @ 1.03").
+
+Alignments (for rel_depth or auxiliary reporting in metric_depth):
+
+* **median scale alignment** ("_scale_med"): scale s = median(d)/median(d̂),
+  then d̂' = s·d̂.
+* **affine depth alignment** ("_affine_depth"): find (a,b) minimizing a·d̂ + b ≈ d
+  (weighted least-squares with w=1/d to better match relative error).
+* **affine disparity alignment** ("_affine_disp"): find (a,b) minimizing
+  a·(1/d̂)+b ≈ (1/d), then convert back to depth.
+  This follows the disparity-affine alignment described in MoGe-2 Appendix A.3.
+
+Code references:
+
+* MoGe-2 evaluation implementation (alignment + depth metrics):
+  - moge_eval/utils/metrics.py (rel_depth, delta metrics)
+  - moge_eval/utils/alignment.py (scale / affine / disparity-affine alignments)
+* MapAnything uses median scale alignment to make scale-invariant metrics.
+
+This file is self-contained (NumPy + OpenCV) so that evaluator can import it
+without pulling training-time dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+
+import cv2
+import numpy as np
+
+EPS = 1e-6
+
+
+@dataclass(frozen=True)
+class DepthEvalConfig:
+    """Configuration for depth evaluation."""
+
+    min_depth: float = 1e-3
+    max_depth: float = float("inf")
+    delta_thresholds: Tuple[float, float] = (1.03, 1.25)
+    clamp_min: float = 1e-6
+
+
+def resize_depth_nearest(depth: np.ndarray, out_hw: Tuple[int, int]) -> np.ndarray:
+    """Resize a single-channel depth map to (H,W) using nearest-neighbor."""
+    h, w = out_hw
+    if depth.shape[0] == h and depth.shape[1] == w:
+        return depth
+    return cv2.resize(depth, (w, h), interpolation=cv2.INTER_NEAREST)
+
+
+def _valid_mask(
+    pred: np.ndarray,
+    gt: np.ndarray,
+    gt_valid: np.ndarray,
+    cfg: DepthEvalConfig,
+) -> np.ndarray:
+    pred = np.asarray(pred)
+    gt = np.asarray(gt)
+    m = np.asarray(gt_valid).astype(bool)
+    m &= np.isfinite(pred) & np.isfinite(gt)
+    m &= gt > cfg.min_depth
+    if np.isfinite(cfg.max_depth):
+        m &= gt < cfg.max_depth
+    m &= pred > cfg.clamp_min
+    return m
+
+
+def abs_rel(pred: np.ndarray, gt: np.ndarray) -> float:
+    return float(np.mean(np.abs(pred - gt) / np.maximum(gt, EPS)))
+
+
+def rmse(pred: np.ndarray, gt: np.ndarray) -> float:
+    return float(np.sqrt(np.mean((pred - gt) ** 2)))
+
+
+def rmse_log(pred: np.ndarray, gt: np.ndarray) -> float:
+    pred = np.maximum(pred, EPS)
+    gt = np.maximum(gt, EPS)
+    return float(np.sqrt(np.mean((np.log(pred) - np.log(gt)) ** 2)))
+
+
+def si_log(pred: np.ndarray, gt: np.ndarray) -> float:
+    """Scale-invariant log RMSE (Eigen et al.)."""
+    pred = np.maximum(pred, EPS)
+    gt = np.maximum(gt, EPS)
+    diff = np.log(pred) - np.log(gt)
+    return float(np.sqrt(np.mean(diff**2) - (np.mean(diff) ** 2)))
+
+
+def delta(pred: np.ndarray, gt: np.ndarray, thr: float) -> float:
+    pred = np.maximum(pred, EPS)
+    gt = np.maximum(gt, EPS)
+    ratio = np.maximum(pred / gt, gt / pred)
+    return float(np.mean(ratio < thr) * 100.0)
+
+
+def median_scale(pred: np.ndarray, gt: np.ndarray) -> float:
+    """Robust global scale s so that median(s·pred) == median(gt)."""
+    p_med = float(np.median(pred))
+    g_med = float(np.median(gt))
+    return g_med / max(p_med, EPS)
+
+
+def fit_affine_l2(x: np.ndarray, y: np.ndarray, w: Optional[np.ndarray] = None) -> Tuple[float, float]:
+    """Fit y ≈ a·x + b by (weighted) least squares."""
+    x = x.reshape(-1).astype(np.float64)
+    y = y.reshape(-1).astype(np.float64)
+    if w is None:
+        A = np.stack([x, np.ones_like(x)], axis=1)
+        sol, *_ = np.linalg.lstsq(A, y, rcond=None)
+        a, b = float(sol[0]), float(sol[1])
+        return a, b
+
+    w = w.reshape(-1).astype(np.float64)
+    w = np.maximum(w, 0.0)
+    # Weighted normal equations: (A^T W A) θ = A^T W y
+    A0 = x
+    A1 = np.ones_like(x)
+    # Compute components explicitly to avoid huge matrices.
+    Sw = w.sum() + EPS
+    Sx = (w * A0).sum()
+    Sy = (w * y).sum()
+    Sxx = (w * A0 * A0).sum()
+    Sxy = (w * A0 * y).sum()
+    # Solve 2x2:
+    # [Sxx Sx] [a] = [Sxy]
+    # [Sx  Sw] [b]   [Sy ]
+    det = Sxx * Sw - Sx * Sx
+    if abs(det) < 1e-12:
+        return 1.0, 0.0
+    a = (Sxy * Sw - Sy * Sx) / det
+    b = (Sxx * Sy - Sx * Sxy) / det
+    return float(a), float(b)
+
+
+def apply_affine_depth(pred: np.ndarray, a: float, b: float, clamp_min: float = 1e-6) -> np.ndarray:
+    out = a * pred + b
+    return np.maximum(out, clamp_min)
+
+
+def apply_affine_disp(pred: np.ndarray, a: float, b: float, clamp_min: float = 1e-6) -> np.ndarray:
+    disp = 1.0 / np.maximum(pred, clamp_min)
+    disp2 = a * disp + b
+    disp2 = np.maximum(disp2, clamp_min)
+    return 1.0 / disp2
+
+
+def compute_depth_metrics(
+    pred_depth: np.ndarray,
+    gt_depth: np.ndarray,
+    gt_valid_mask: np.ndarray,
+    cfg: DepthEvalConfig = DepthEvalConfig(),
+) -> Dict[str, float]:
+    """Compute a bundle of depth metrics for a single image."""
+    pred = np.asarray(pred_depth).astype(np.float32)
+    gt = np.asarray(gt_depth).astype(np.float32)
+    valid = _valid_mask(pred, gt, gt_valid_mask, cfg)
+
+    n_valid = int(valid.sum())
+    if n_valid == 0:
+        return {}
+
+    p = pred[valid]
+    g = gt[valid]
+
+    out: Dict[str, float] = {}
+    # Percentage of pixels used for evaluation after applying:
+    # (1) dataset GT valid mask, (2) GT depth range checks, (3) finite/positive checks.
+    # Useful for sparse GT depth (e.g., ETH3D); clarifies this is the eval mask (GT∩pred).
+    out["valid_pixels_pct"] = float(100.0 * n_valid / float(max(valid.size, 1)))
+
+    # --- Raw / metric metrics (no alignment) ---
+    out["abs_rel"] = abs_rel(p, g)
+    out["rmse"] = rmse(p, g)
+    out["rmse_log"] = rmse_log(p, g)
+    out["si_log"] = si_log(p, g)
+    for t in cfg.delta_thresholds:
+        out[f"delta_{t}"] = delta(p, g, t)
+
+    # --- Median scale alignment (relative depth quality) ---
+    s_med = median_scale(p, g)
+    out["scale_med"] = float(s_med)
+    out["metric_scale_rel"] = float(abs(s_med - 1.0))
+    out["metric_scale_log"] = float(abs(np.log(max(s_med, EPS))))
+
+    p_med = p * s_med
+    out["abs_rel_scale_med"] = abs_rel(p_med, g)
+    for t in cfg.delta_thresholds:
+        out[f"delta_{t}_scale_med"] = delta(p_med, g, t)
+
+    # --- Affine depth alignment (scale+shift invariance) ---
+    w = 1.0 / np.maximum(g, EPS)  # match relative error emphasis
+    a_d, b_d = fit_affine_l2(p, g, w=w)
+    out["affine_depth_scale"] = float(a_d)
+    out["affine_depth_shift"] = float(b_d)
+    p_aff_d = apply_affine_depth(p, a_d, b_d, clamp_min=cfg.clamp_min)
+    out["abs_rel_affine_depth"] = abs_rel(p_aff_d, g)
+    for t in cfg.delta_thresholds:
+        out[f"delta_{t}_affine_depth"] = delta(p_aff_d, g, t)
+
+    # --- Affine disparity alignment (scale+shift invariance in inverse depth) ---
+    p_disp = 1.0 / np.maximum(p, cfg.clamp_min)
+    g_disp = 1.0 / np.maximum(g, cfg.clamp_min)
+    a_id, b_id = fit_affine_l2(p_disp, g_disp, w=None)
+    out["affine_disp_scale"] = float(a_id)
+    out["affine_disp_shift"] = float(b_id)
+    p_aff_id = apply_affine_disp(p, a_id, b_id, clamp_min=cfg.clamp_min)
+    out["abs_rel_affine_disp"] = abs_rel(p_aff_id, g)
+    for t in cfg.delta_thresholds:
+        out[f"delta_{t}_affine_disp"] = delta(p_aff_id, g, t)
+
+    return out


### PR DESCRIPTION
# Add relative + metric depth + global scale evaluation (`rel_depth`, `metric_depth`) to DA3 benchmark

## What / Why

The benchmark already covers pose and reconstruction (`pose`, `recon_unposed`, `recon_posed`). This PR adds **depth-quality evaluation** so we can measure how good the predicted depth maps are on datasets that provide GT depth, and do it consistently across *any-view* setups (varying #views, posed/unposed inference, etc.).

This PR is related to evaluation depth estimation quality / global scale as MapAnything provides. https://github.com/ByteDance-Seed/Depth-Anything-3/issues/29.

The goal here is simple:
- **Relative depth quality** (shape) → “does the depth map look right up to an unknown scale / affine?”
- **Metric depth quality** (absolute) → “is the depth map correct in meters, without alignment?”
- **Metric scale accuracy** → “if the model is *almost* metric, how far off is its scale?”

We tried to follow the common evaluation protocol used by **MoGe-2** (scale/affine alignment variants) and **MapAnything** (AbsRel + inlier ratio at τ=1.03%, with multi-view sweeps). We did not run an exhaustive sweep across all scenes, but we sanity-checked outputs on 4 datasets (7Scenes / HiRoom / ScanNet++ / ETH3D) and the numbers look in the expected range.

## What’s included

### New evaluation modes
- `rel_depth`: reports **scale-invariant** and **affine-invariant** depth metrics
- `metric_depth`: reports **raw metric** depth metrics + **scale diagnostics**

Both modes write JSON to:
- `workspace/evaluation/metric_results/<dataset>_rel_depth.json`
- `workspace/evaluation/metric_results/<dataset>_metric_depth.json`

### Printer update
The benchmark printer now groups depth metrics by interpretation:
- **Scale-invariant** (median aligned)
- **Affine-invariant** (depth and disparity)
- **Metric** (no alignment)
- **Scale diagnostics** (median scale factor, metric-scale error, valid pixels %)

### ETH3D GT loading fixes (already in your branch)
ETH3D depth/mask paths are derived from `dataset.data_root`, and masks are searched in:
1) `masks_for_images/dslr_images/<image>.png` (preferred)
2) `ground_truth_masks/dslr_images/<image>` (fallback)

This matches the actual dataset layout and avoids crashing when optional masks are missing.

## How to run (repro)

Example reproduction (single ScanNet++ scene):

```bash
python -m depth_anything_3.bench.evaluator \
model.path="depth-anything/DA3NESTED-GIANT-LARGE-1.1" \
eval.datasets=[scannetpp] \
eval.scenes="1ada7a0617" \
eval.ref_view_strategy="saddle_balanced" \
eval.modes=[rel_depth,metric_depth]
```

The benchmark still supports:
- pose-only
- recon-only
- print-only
- eval-only
(unchanged)

## Interpreting the metrics (quick cheatsheet)

All metrics are computed **per-image**, then averaged per-scene.

### “Scale-inv AbsRel (med)” / “Scale-inv δ@…”
We find a single scalar `s_med` such that `median(s_med * pred) == median(gt)` on valid pixels, and evaluate on `pred * s_med`.
- This removes global scale bias but keeps “shape” errors.
- For models that are already close to metric, `s_med` will be close to 1.0 and the aligned numbers will be similar to raw metric numbers.

### “Affine-inv … (depth)”
Fits `a * pred + b` to match GT depth (weighted toward relative errors). This removes both scale and shift.
- Useful if a method’s output has an additive bias (common in some representations).

### “Affine-inv … (disp)”
Fits an affine mapping in **disparity** (inverse depth), then converts back to depth.
- This is commonly used when models are trained/predicted in disparity space (or behave closer to a disparity-affine transform).

### “Metric …”
Raw metrics on the predicted depth **without any alignment** (i.e., “are you in meters?”).

#### Metric-depth error terms (in `*_metric_depth.json`)
- `rmse`: root-mean-square error in depth units (usually meters). Sensitive to large outliers.
- `rmse_log`: RMSE in log-depth space (uses `log(depth)`), so it behaves more like a multiplicative / relative error.
- `si_log`: *scale-invariant* log RMSE, computed as `sqrt(mean(d^2) - mean(d)^2)` with `d = log(pred) - log(gt)`. This reduces the impact of a global scale shift and focuses more on shape.
- `valid_pixels_pct`: percentage of pixels that actually participated in evaluation after applying the GT validity mask (and any dataset-provided masks). This is computed per-image, then averaged per-scene.

### “Median scale (s)” + “Metric scale rel”
- `Median scale (s)` is the median-alignment factor `s_med`.
- `Metric scale rel = |s_med - 1|` summarizes how far the model’s absolute scale is from perfect metric.
- `Metric scale log = |log(s_med)|` is the same idea in log space (symmetric for over-/under-scaling).
- `Valid pixels (%)` tells you how much of the image actually participated in evaluation after GT validity + basic checks.


### Notes: `rmse`/`rmse_log` and `metric_scale_rel`/`metric_scale_log` redundant?
They measure different things:
- `rmse` and `rmse_log`: per-pixel depth error (shape + scale + local noise).
- `metric_scale_rel` and `metric_scale_log`: global scale error only (derived from `scale_med`).

They may correlate in practice, but scale diagnostics are still useful for quickly answering:
“Is the model wrong because the whole scene is scaled incorrectly, or because local depth is noisy?”

## Worked example (ScanNet++ `1ada7a0617`)

### Console output
```
📏 DEPTH ESTIMATION
---------------------------------------------------------------------------------------
Metric                     Avg         HiRoom      ETH3D       7Scenes     ScanNet++
---------------------------------------------------------------------------------------
Scale-inv AbsRel (med)     0.0309      N/A         N/A         N/A         0.0309
Scale-inv δ@1.03 (med)     76.7523     N/A         N/A         N/A         76.7523
Scale-inv δ@1.25 (med)     97.8438     N/A         N/A         N/A         97.8438
---------------------------------------------------------------------------------------
Affine-inv AbsRel (depth)  0.0285      N/A         N/A         N/A         0.0285
Affine-inv δ@1.03 (depth)  81.0307     N/A         N/A         N/A         81.0307
Affine-inv δ@1.25 (depth)  97.8475     N/A         N/A         N/A         97.8475
Affine-inv AbsRel (disp)   0.0285      N/A         N/A         N/A         0.0285
Affine-inv δ@1.03 (disp)   81.7547     N/A         N/A         N/A         81.7547
Affine-inv δ@1.25 (disp)   97.8475     N/A         N/A         N/A         97.8475
---------------------------------------------------------------------------------------
Metric AbsRel              0.0309      N/A         N/A         N/A         0.0309
Metric δ@1.03              78.5885     N/A         N/A         N/A         78.5885
Metric δ@1.25              97.8394     N/A         N/A         N/A         97.8394
---------------------------------------------------------------------------------------
Median scale (s)           1.0153      N/A         N/A         N/A         1.0153
Metric scale rel           0.0170      N/A         N/A         N/A         0.0170
Valid pixels (%)           98.3680     N/A         N/A         N/A         98.3680
```

### What this says (plain English)
- The model is already **very close to metric** here: `s_med ≈ 1.015`, meaning the median scale is ~+1.5% vs GT.
- `Metric scale rel ≈ 0.017` matches that: about **1.7%** scale error overall.
- Scale-invariant AbsRel is ~0.031, so after removing global scale, the “shape” error is still around 3%.
- Allowing a full affine correction improves AbsRel a bit (~0.0285), suggesting there’s a small systematic bias that a +b term can absorb.

### JSON outputs
- `scannetpp_metric_depth.json` contains raw metric-depth metrics + scale diagnostics
- `scannetpp_rel_depth.json` contains scale/affine-invariant metrics

For details, please see the following attached json files.
[scannetpp_metric_depth.json](https://github.com/user-attachments/files/24141040/scannetpp_metric_depth.json)
[scannetpp_rel_depth.json](https://github.com/user-attachments/files/24141045/scannetpp_rel_depth.json)

## Files changed

- `src/depth_anything_3/bench/depth_metrics.py` (new): depth metrics + alignment helpers
- `src/depth_anything_3/bench/evaluator.py`: add modes + GT depth loading + JSON outputs
- `src/depth_anything_3/bench/print_metrics.py`: grouped depth printer
- `src/depth_anything_3/bench/configs/eval_bench.yaml`: expose new modes
- `docs/BENCHMARK.md`: document new modes & example commands

## Notes / Limitations

- This PR evaluates **per-view depth maps** against GT depth. It does not attempt to score “cross-view consistency” directly.
- Masking uses dataset GT validity + dataset-provided masks where available. We don’t currently gate evaluation by model confidence (unless the dataset’s GT mask already removes regions like sky).

---

### Checklist

- [x] Ran at least one scene for each dataset (ETH3D / 7Scenes / ScanNet++ / HiRoom)
- [ ] Compare results with MoGe-2/MapAnything
- [ ] Make depth evaluation code faster
