### PR TITLE
Fix normalization in vision transformer outputs

### DIFF
--- a/src/depth_anything_3/model/dinov2/vision_transformer.py
+++ b/src/depth_anything_3/model/dinov2/vision_transformer.py
@@ -385,7 +385,7 @@ class DinoVisionTransformer(nn.Module):
         elif outputs[0][1].shape[-1] == (self.embed_dim * 2):
             outputs = [
                 torch.cat(
-                    [out[1][..., : self.embed_dim], self.norm(out[1][..., self.embed_dim :])],
+                    [self.norm(out[1][..., : self.embed_dim]), self.norm(out[1][..., self.embed_dim :])],
                     dim=-1,
                 )
                 for out in outputs


### PR DESCRIPTION
When cat_token=True, the code manually splits the output tensor to fit self.norm (which expects embed_dim). It appears the normalization step was accidentally skipped for the first half (local features), while the second half is correctly normalized.

This results in a single output tensor containing mixed scales, which contradicts the behavior of cat_token=False where the full signal is normalized.