### PR TITLE
Fix: Align auxiliary output features with input view order

### DIFF
--- a/src/depth_anything_3/model/dinov2/vision_transformer.py
+++ b/src/depth_anything_3/model/dinov2/vision_transformer.py
@@ -345,7 +345,11 @@ class DinoVisionTransformer(nn.Module):
                     out_x = restore_original_order(out_x, b_idx)
                 output.append((out_x[:, :, 0], out_x))
             if i in export_feat_layers:
-                aux_output.append(x)
+                # Apply the same restoration logic to auxiliary features to align with input view order
+                aux_x = x.clone()
+                if x.shape[1] >= THRESH_FOR_REF_SELECTION and self.alt_start != -1 and 'b_idx' in locals():
+                    aux_x = restore_original_order(aux_x, b_idx)
+                aux_output.append(aux_x)
         return output, aux_output
 
     def process_attention(self, x, block, attn_type="global", pos=None, attn_mask=None):


### PR DESCRIPTION
## Summary
This PR fixes a misalignment issue in `aux_output` (exported intermediate features) within `_get_intermediate_layers_not_chunked`.

## Problem
Currently, when the model selects a dynamic reference view and reorders the input tensor `x` (placing the reference view at index 0), the main output is correctly restored to the original input order using `restore_original_order`.

However, the auxiliary features (`aux_output`) append `x` directly in its reordered state. This causes a mismatch where the order of features in `output.aux` does not correspond to the order of the input images (specifically when exporting features for layers where `i >= alt_start`), breaking downstream tasks that rely on index alignment (e.g., visualization, consistency checks).

## Changes
- Replicated the view restoration logic used for the main output in the auxiliary output block.
- Added checks to ensure `restore_original_order` is only called when reordering actually occurred (checking `b_idx` and thresholds).