### PR TITLE
Feature: Add padding and alpha blending support to `InputProcessor`

### DIFF
--- a/src/depth_anything_3/api.py
+++ b/src/depth_anything_3/api.py
@@ -63,8 +63,8 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         # Load from Hugging Face Hub
         model = DepthAnything3.from_pretrained("huggingface/model-name")
 
-        # Or create with specific preset
-        model = DepthAnything3(preset="vitg")
+        # Or create with a specific model from a predefined config
+        model = DepthAnything3(model_name="da3-large")
 
         # Run inference
         prediction = model.inference(images, export_dir="output", export_format="glb")

--- a/src/depth_anything_3/api.py
+++ b/src/depth_anything_3/api.py
@@ -156,6 +156,7 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         # Other export parameters, e.g., gs_ply, gs_video
         export_kwargs: Optional[dict] = {},
         alpha_blend_method: str = "mean",
+        batch_method: str = "center_crop",
     ) -> Prediction:
         """
         Run inference on input images.
@@ -187,6 +188,8 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
                 Options: "keep", "white", "black", "mean". The "keep" option keeps the original
                 image pixels, the "mean" option blends the images using the imagenet mean values.
                 Default: "mean".
+            batch_method: Batch processing method for input images.
+                Options: "pad", "center_crop". Default: "center_crop".
 
         Returns:
             Prediction object containing depth maps and camera parameters
@@ -198,8 +201,19 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
             assert isinstance(image[0], str), "`image` must be image paths for COLMAP export."
 
         # Preprocess images
-        imgs_cpu, extrinsics, intrinsics = self._preprocess_inputs(
-            image, extrinsics, intrinsics, process_res, process_res_method, alpha_blend_method,
+        (
+            imgs_cpu,
+            masks_cpu,
+            extrinsics,
+            intrinsics,
+        ) = self._preprocess_inputs(
+            image=image,
+            extrinsics=extrinsics,
+            intrinsics=intrinsics,
+            process_res=process_res,
+            process_res_method=process_res_method,
+            alpha_blend_method=alpha_blend_method,
+            batch_method=batch_method,
         )
 
         # Prepare tensors for model
@@ -225,6 +239,7 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
 
         # Add processed images for visualization
         prediction = self._add_processed_images(prediction, imgs_cpu)
+        prediction = self._add_alpha_masks(prediction, masks_cpu)
 
         # Export if requested
         if export_dir is not None:
@@ -285,16 +300,18 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         process_res: int = 504,
         process_res_method: str = "upper_bound_resize",
         alpha_blend_method: str = "mean",
+        batch_method: str = "center_crop",
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """Preprocess input images using input processor."""
         start_time = time.time()
-        imgs_cpu, extrinsics, intrinsics = self.input_processor(
+        imgs_cpu, masks_cpu, extrinsics, intrinsics = self.input_processor(
             image=image,
             extrinsics=extrinsics.copy() if extrinsics is not None else None,
             intrinsics=intrinsics.copy() if intrinsics is not None else None,
             process_res=process_res,
             process_res_method=process_res_method,
             alpha_blend_method=alpha_blend_method,
+            batch_method=batch_method,
         )
         end_time = time.time()
         logger.info(
@@ -303,7 +320,7 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
             "seconds. Shape: ",
             imgs_cpu.shape,
         )
-        return imgs_cpu, extrinsics, intrinsics
+        return imgs_cpu, masks_cpu, extrinsics, intrinsics
 
     def _prepare_model_inputs(
         self,
@@ -403,7 +420,8 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         logger.info(f"Conversion to Prediction Done. Time: {end_time - start_time} seconds")
         return output
 
-    def _add_processed_images(self, prediction: Prediction, imgs_cpu: torch.Tensor) -> Prediction:
+    @staticmethod
+    def _add_processed_images(prediction: Prediction, imgs_cpu: torch.Tensor) -> Prediction:
         """Add processed images to prediction for visualization."""
         # Convert from (N, 3, H, W) to (N, H, W, 3) and denormalize
         processed_imgs = imgs_cpu.permute(0, 2, 3, 1).cpu().numpy()  # (N, H, W, 3)
@@ -416,6 +434,12 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         processed_imgs = (processed_imgs * 255).astype(np.uint8)
 
         prediction.processed_images = processed_imgs
+        return prediction
+
+    @staticmethod
+    def _add_alpha_masks(prediction: Prediction, masks_cpu: torch.Tensor) -> Prediction:
+        """Add alpha masks to prediction for visualization."""
+        prediction.alpha_masks = masks_cpu.cpu().numpy()
         return prediction
 
     def _export_results(

--- a/src/depth_anything_3/api.py
+++ b/src/depth_anything_3/api.py
@@ -155,6 +155,7 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         feat_vis_fps: int = 15,
         # Other export parameters, e.g., gs_ply, gs_video
         export_kwargs: Optional[dict] = {},
+        alpha_blend_method: str = "mean",
     ) -> Prediction:
         """
         Run inference on input images.
@@ -182,6 +183,10 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
             show_cameras: [GLB] Show camera wireframes in the exported scene (default: True)
             feat_vis_fps: [FEAT_VIS] Frame rate for output video (default: 15)
             export_kwargs: additional arguments to export functions.
+            alpha_blend_method: Alpha blending method for images with an alpha channel.
+                Options: "keep", "white", "black", "mean". The "keep" option keeps the original
+                image pixels, the "mean" option blends the images using the imagenet mean values.
+                Default: "mean".
 
         Returns:
             Prediction object containing depth maps and camera parameters
@@ -194,7 +199,7 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
 
         # Preprocess images
         imgs_cpu, extrinsics, intrinsics = self._preprocess_inputs(
-            image, extrinsics, intrinsics, process_res, process_res_method
+            image, extrinsics, intrinsics, process_res, process_res_method, alpha_blend_method,
         )
 
         # Prepare tensors for model
@@ -279,15 +284,17 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         intrinsics: np.ndarray | None = None,
         process_res: int = 504,
         process_res_method: str = "upper_bound_resize",
+        alpha_blend_method: str = "mean",
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """Preprocess input images using input processor."""
         start_time = time.time()
         imgs_cpu, extrinsics, intrinsics = self.input_processor(
-            image,
-            extrinsics.copy() if extrinsics is not None else None,
-            intrinsics.copy() if intrinsics is not None else None,
-            process_res,
-            process_res_method,
+            image=image,
+            extrinsics=extrinsics.copy() if extrinsics is not None else None,
+            intrinsics=intrinsics.copy() if intrinsics is not None else None,
+            process_res=process_res,
+            process_res_method=process_res_method,
+            alpha_blend_method=alpha_blend_method,
         )
         end_time = time.time()
         logger.info(

--- a/src/depth_anything_3/specs.py
+++ b/src/depth_anything_3/specs.py
@@ -35,6 +35,7 @@ class Gaussians:
 class Prediction:
     depth: np.ndarray  # N, H, W
     is_metric: int
+    alpha_masks: np.ndarray | None = None  # N, H, W - alpha mask in 0-1 range
     sky: np.ndarray | None = None  # N, H, W
     conf: np.ndarray | None = None  # N, H, W
     extrinsics: np.ndarray | None = None  # N, 4, 4

--- a/src/depth_anything_3/utils/io/input_processor.py
+++ b/src/depth_anything_3/utils/io/input_processor.py
@@ -56,11 +56,13 @@ class InputProcessor:
       - Order of outputs matches the input order.
     """
 
-    NORMALIZE = T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD)
     PATCH_SIZE = 14
 
     def __init__(self):
-        pass
+        self._normalize_image = T.Compose([
+            T.ToTensor(),
+            T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ])
 
     # -----------------------------
     # Public API
@@ -312,10 +314,6 @@ class InputProcessor:
             return img.convert("RGB")
         else:
             raise ValueError(f"Unsupported image type: {type(img)}")
-
-    def _normalize_image(self, img: Image.Image) -> torch.Tensor:
-        img_tensor = T.ToTensor()(img)
-        return self.NORMALIZE(img_tensor)
 
     # -----------------------------
     # Boundary resizing

--- a/src/depth_anything_3/utils/io/input_processor.py
+++ b/src/depth_anything_3/utils/io/input_processor.py
@@ -111,8 +111,8 @@ def _unify_batch_shapes(
                 new_ixts.append(None)
             else:
                 K_adj = K.copy()
-                K_adj[0, 2] = max_w
-                K_adj[1, 2] = max_h
+                K_adj[0, 2] += horizontal_padding
+                K_adj[1, 2] += vertical_padding
                 new_ixts.append(K_adj)
 
         return new_imgs, new_masks, new_sizes, new_ixts


### PR DESCRIPTION
### Summary
- Refactored `InputProcessor`:
  - Moved helper functions to the global scope for reusability.
  - Replaced the class-level `NORMALIZE` constant with an instance-specific normalization pipeline.
  - Introduced constants for normalization to simplify utility logic.
- Introduced alpha blending functionality in the `InputProcessor` image pipeline.
- Updated API with new alpha blending modes (`keep`, `white`, `black`, `mean`).
- Added alpha masks to the `InputProcessor` output.
- Added alpha masks to the `Prediction` class.
- Updated API to return alpha masks in prediction.
- Added padding support for batch processing in `InputProcessor`.
- Updated API with new batch processing modes (`center_crop`, `pad`).


