### PR TITLE
fix misleading comments on c2w conversion in da3.py

### DIFF
--- a/src/depth_anything_3/model/da3.py
+++ b/src/depth_anything_3/model/da3.py
@@ -189,7 +189,7 @@ class DepthAnything3Net(nn.Module):
                 output.ray.shape[-3],
                 output.ray.shape[-2],
             )
-            pred_extrinsic = affine_inverse(pred_extrinsic) # w2c -> c2w
+            pred_extrinsic = affine_inverse(pred_extrinsic) # c2w -> w2c
             pred_extrinsic = pred_extrinsic[:, :, :3, :]
             pred_intrinsic = torch.eye(3, 3)[None, None].repeat(pred_extrinsic.shape[0], pred_extrinsic.shape[1], 1, 1).clone().to(pred_extrinsic.device)
             pred_intrinsic[:, :, 0, 0] = pred_focal_lengths[:, :, 0] / 2 * width


### PR DESCRIPTION
In `src/depth_anything_3/model/da3.py`, within `_process_ray_pose_estimation`, the `pred_extrinsic` derived from `get_extrinsic_from_camray` should be **c2w** (camera-to-world) transform, not **w2c** (world-to-camera) as in the comment.

This PR fixes the misleading comment.