### PR TITLE
chore(deps): remove xformers from default deps for macOS compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "imageio",
     "numpy<2",
     "opencv-python",
-    "xformers",
     "open3d",
     "fastapi",
     "uvicorn",


### PR DESCRIPTION
## Summary
- remove `xformers` from default `pyproject.toml` dependencies
- keep dependency set aligned with macOS-compatible install path

## Why
`xformers` is not reliably installable on macOS and breaks default dependency installation.

## Scope
- packaging dependency metadata only
- no runtime/model code changes