### PR TITLE
[BUG]: fixed export of gs_ply and gs_video

### DIFF
--- a/src/depth_anything_3/api.py
+++ b/src/depth_anything_3/api.py
@@ -224,19 +224,6 @@ class DepthAnything3(nn.Module, PyTorchModelHubMixin):
         # Export if requested
         if export_dir is not None:
 
-            if "gs" in export_format:
-                if infer_gs and "gs_video" not in export_format:
-                    export_format = f"{export_format}-gs_video"
-                if "gs_video" in export_format:
-                    if "gs_video" not in export_kwargs:
-                        export_kwargs["gs_video"] = {}
-                    export_kwargs["gs_video"].update(
-                        {
-                            "extrinsics": render_exts,
-                            "intrinsics": render_ixts,
-                            "out_image_hw": render_hw,
-                        }
-                    )
             # Add GLB export parameters
             if "glb" in export_format:
                 if "glb" not in export_kwargs:

--- a/src/depth_anything_3/utils/export/gs.py
+++ b/src/depth_anything_3/utils/export/gs.py
@@ -15,6 +15,7 @@
 import os
 from typing import Literal, Optional
 import moviepy.editor as mpy
+from moviepy.video.io.ffmpeg_writer import ffmpeg_write_video
 import torch
 
 from depth_anything_3.model.utils.gs_renderer import run_renderer_in_chunk_w_trj_mode
@@ -119,11 +120,10 @@ def export_to_gs_video(
     )
 
     # save as video
+    preset = VIDEO_QUALITY_MAP[video_quality]["preset"]
     ffmpeg_params = [
         "-crf",
         VIDEO_QUALITY_MAP[video_quality]["crf"],
-        "-preset",
-        VIDEO_QUALITY_MAP[video_quality]["preset"],
         "-pix_fmt",
         "yuv420p",
     ]  # best compatibility
@@ -144,11 +144,14 @@ def export_to_gs_video(
         output_name = f"{idx:04d}_{trj_mode}" if output_name is None else output_name
         save_path = os.path.join(export_dir, f"gs_video/{output_name}.mp4")
         # clip.write_videofile(save_path, codec="libx264", audio=False, bitrate="4000k")
-        clip.write_videofile(
-            save_path,
-            codec="libx264",
-            audio=False,
+        ffmpeg_write_video(
+            clip,
+            filename=save_path,
             fps=fps,
+            codec="libx264",
+            preset=preset,
+            audiofile=None,
             ffmpeg_params=ffmpeg_params,
+            logger="bar",
         )
     return


### PR DESCRIPTION
Fix: gs_ply export incorrectly triggers gs_video + gs_video TypeError crash

Problem:
Requesting export_format="gs_ply" incorrectly also runs gs_video generation, which crashes. Related to #239.

Root Causes
api.py: Auto-appends "gs_video" to export format when any "gs" substring is detected (too broad)
utils/export/gs.py: write_videofile() wrapper fails when fps=None

Changes
api.py: Removed automatically adding gs_video in the export_format

utils/export/gs.py: Replaced write_videofile() with direct ffmpeg_write_video() call to bypass broken fps validation