### PR TITLE
Add voxelization based colmap export

### DIFF
--- a/src/depth_anything_3/utils/export/colmap.py
+++ b/src/depth_anything_3/utils/export/colmap.py
@@ -31,9 +31,16 @@ def export_to_colmap(
     image_paths: list[str],
     conf_thresh_percentile: float = 40.0,
     process_res_method: str = "upper_bound_resize",
+    voxel_size: float = 0.05,  # Merge points within 5cm. Increase for fewer points.
 ) -> None:
-    # 1. Data preparation
+    """
+    Exports ML-based depth and poses to COLMAP format with voxel downsampling
+    to ensure 3D points have tracks across multiple frames.
+    """
+    # 1. Data preparation (Filtered by confidence)
     conf_thresh = np.percentile(prediction.conf, conf_thresh_percentile)
+
+    # Get 3D points and colors (using your existing internal helper)
     points, colors = _depths_to_world_points_with_colors(
         prediction.depth,
         prediction.intrinsics,
@@ -42,32 +49,54 @@ def export_to_colmap(
         prediction.conf,
         conf_thresh,
     )
-    num_points = len(points)
-    logger.info(f"Exporting to COLMAP with {num_points} points")
+
     num_frames = len(prediction.processed_images)
     h, w = prediction.processed_images.shape[1:3]
-    points_xyf = _create_xyf(num_frames, h, w)
-    points_xyf = points_xyf[prediction.conf >= conf_thresh]
 
-    # 2. Set Reconstruction
+    # Create pixel coordinates corresponding to each point
+    all_xyf = _create_xyf(num_frames, h, w)
+    points_xyf = all_xyf[prediction.conf >= conf_thresh]
+
+    # 2. Voxel Downsampling & Merging (This creates the Tracks)
+    # Group points by their grid location in 3D space
+    v_keys = (points / voxel_size).astype(int)
+    unique_v_keys, inverse_indices = np.unique(v_keys, axis=0, return_inverse=True)
+    num_voxels = len(unique_v_keys)
+
+    logger.info(
+        f"Merging {len(points)} pixels into {num_voxels} unique 3D points (voxel_size={voxel_size})"
+    )
+
+    # Compute mean 3D position and color for each voxel group
+    voxel_points = np.zeros((num_voxels, 3))
+    voxel_colors = np.zeros((num_voxels, 3))
+    counts = np.zeros(num_voxels)
+    np.add.at(voxel_points, inverse_indices, points)
+    np.add.at(voxel_colors, inverse_indices, colors)
+    np.add.at(counts, inverse_indices, 1)
+
+    voxel_points /= counts[:, None]
+    voxel_colors = (voxel_colors / counts[:, None]).astype(np.uint8)
+
+    # 3. Initialize Reconstruction
     reconstruction = pycolmap.Reconstruction()
-
     point3d_ids = []
-    for vidx in range(num_points):
-        point3d_id = reconstruction.add_point3D(points[vidx], pycolmap.Track(), colors[vidx])
-        point3d_ids.append(point3d_id)
+    for i in range(num_voxels):
+        # Create a new 3D point in the model. Initially it has an empty track.
+        pid = reconstruction.add_point3D(voxel_points[i], pycolmap.Track(), voxel_colors[i])
+        point3d_ids.append(pid)
 
+    # 4. Loop through frames to add Cameras and link 2D observations to 3D points
     for fidx in range(num_frames):
         orig_w, orig_h = Image.open(image_paths[fidx]).size
 
-        intrinsic = prediction.intrinsics[fidx]
+        # Scaling intrinsics to match original image size
+        intrinsic = prediction.intrinsics[fidx].copy()
         if process_res_method.endswith("resize"):
-            intrinsic[:1] *= orig_w / w
-            intrinsic[1:2] *= orig_h / h
-        elif process_res_method == "crop":
-            raise NotImplementedError("COLMAP export for crop method is not implemented")
-        else:
-            raise ValueError(f"Unknown process_res_method: {process_res_method}")
+            intrinsic[0, 0] *= orig_w / w
+            intrinsic[1, 1] *= orig_h / h
+            intrinsic[0, 2] *= orig_w / w
+            intrinsic[1, 2] *= orig_h / h
 
         pycolmap_intri = np.array(
             [intrinsic[0, 0], intrinsic[1, 1], intrinsic[0, 2], intrinsic[1, 2]]
@@ -104,16 +133,30 @@ def export_to_colmap(
         frame.rig_from_world = cam_from_world
         reconstruction.add_frame(frame)
 
-        # set point2d and update track
+        # Link 2D pixels to the voxelized 3D points
         point2d_list = []
-        points_in_frame = points_xyf[:, 2].astype(np.int32) == fidx
-        for vidx in np.where(points_in_frame)[0]:
-            point2d = points_xyf[vidx][:2]
+        in_frame_indices = np.where(points_xyf[:, 2] == fidx)[0]
+
+        # Prevent adding the same 3D point twice to a single image
+        seen_voxels_in_this_image = set()
+
+        for idx in in_frame_indices:
+            voxel_idx = inverse_indices[idx]
+
+            if voxel_idx in seen_voxels_in_this_image:
+                continue
+            seen_voxels_in_this_image.add(voxel_idx)
+
+            point2d = points_xyf[idx][:2].astype(float).copy()
             point2d[0] *= orig_w / w
             point2d[1] *= orig_h / h
-            point3d_id = point3d_ids[vidx]
-            point2d_list.append(pycolmap.Point2D(point2d, point3d_id))
-            reconstruction.point3D(point3d_id).track.add_element(
+
+            pt3d_id = point3d_ids[voxel_idx]
+            point2d_list.append(pycolmap.Point2D(point2d, pt3d_id))
+
+            # This is the crucial step: add this observation to the track.
+            # point3D.track now contains multiple images that see the same physical point.
+            reconstruction.point3D(pt3d_id).track.add_element(
                 image.image_id, len(point2d_list) - 1
             )
 
@@ -123,8 +166,11 @@ def export_to_colmap(
         image.points2D = pycolmap.Point2DList(point2d_list)
         reconstruction.add_image(image)
 
-    # 3. Export
+    # 5. Export to disk
+    os.makedirs(export_dir, exist_ok=True)
     reconstruction.write(export_dir)
+    reconstruction.write_text(export_dir)
+    logger.info(f"Successfully exported COLMAP model to {export_dir}")
 
 
 def _create_xyf(num_frames, height, width):


### PR DESCRIPTION
### What does this PR do?
Introduces voxelization for 3D points before exporting them to the COLMAP format.

### Why is it needed?
Exporting entire point clouds can result in excessively large files. Voxelizing the points beforehand provides users with an efficient way to downsample the data to their required density, reducing export time and file size.

### Implementation Details
- Integrates voxelization logic into the COLMAP export function.
- Enables downsampling based on user-defined voxel size.