### PR TITLE
fix(mac): get training and inference working on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "depth-anything-3"
 version = "0.0.0"
 description = "Depth Anything 3"
 readme = "README.md"
-requires-python = ">=3.9, <=3.13"
+requires-python = ">=3.10, <=3.13"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Your Name" }]
 
@@ -21,7 +21,7 @@ dependencies = [
     "imageio",
     "numpy<2",
     "opencv-python",
-    "xformers",
+    # "xformers", # Commented out to support macOS/MPS/CPU (xformers is CUDA-only)
     "open3d",
     "fastapi",
     "uvicorn",
@@ -43,8 +43,9 @@ dependencies = [
 
 [project.optional-dependencies]
 app = ["gradio>=5", "pillow>=9.0"] # requires that python3>=3.10
-gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70"]
-all = ["depth-anything-3[app,gs]"]
+# Commented out to support macOS/MPS/CPU (gsplat requires CUDA compilation)
+# gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70"]
+# all = ["depth-anything-3[app,gs]"]
 
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "imageio",
     "numpy<2",
     "opencv-python",
-    # "xformers", # Commented out to support macOS/MPS/CPU (xformers is CUDA-only)
+    "xformers; sys_platform != 'darwin'",
     "open3d",
     "fastapi",
     "uvicorn",
@@ -43,9 +43,8 @@ dependencies = [
 
 [project.optional-dependencies]
 app = ["gradio>=5", "pillow>=9.0"] # requires that python3>=3.10
-# Commented out to support macOS/MPS/CPU (gsplat requires CUDA compilation)
-# gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70"]
-# all = ["depth-anything-3[app,gs]"]
+gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70; sys_platform != 'darwin'"]
+all = ["depth-anything-3[app,gs]"]
 
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "imageio",
     "numpy<2",
     "opencv-python",
-    "xformers; sys_platform != 'darwin'",
+    # "xformers", # Commented out to support macOS/MPS/CPU (xformers is CUDA-only)
     "open3d",
     "fastapi",
     "uvicorn",
@@ -43,8 +43,9 @@ dependencies = [
 
 [project.optional-dependencies]
 app = ["gradio>=5", "pillow>=9.0"] # requires that python3>=3.10
-gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70; sys_platform != 'darwin'"]
-all = ["depth-anything-3[app,gs]"]
+# Commented out to support macOS/MPS/CPU (gsplat requires CUDA compilation)
+# gs = ["gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@0b4dddf04cb687367602c01196913cde6a743d70"]
+# all = ["depth-anything-3[app,gs]"]
 
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ huggingface_hub
 imageio
 numpy<2
 opencv-python
-xformers; sys_platform != 'darwin'
+# xformers # Commented out to support macOS/MPS/CPU (CUDA-only)
 open3d
 fastapi
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ huggingface_hub
 imageio
 numpy<2
 opencv-python
-xformers
+# xformers # Commented out to support macOS/MPS/CPU (CUDA-only)
 open3d
 fastapi
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ huggingface_hub
 imageio
 numpy<2
 opencv-python
-# xformers # Commented out to support macOS/MPS/CPU (CUDA-only)
+xformers; sys_platform != 'darwin'
 open3d
 fastapi
 uvicorn

--- a/src/depth_anything_3/cli.py
+++ b/src/depth_anything_3/cli.py
@@ -20,6 +20,9 @@ Clean, modular command-line interface
 from __future__ import annotations
 
 import os
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE" # Prevent OpenMP double initialization crash on macOS
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import typer
 
 from depth_anything_3.services import start_server
@@ -39,8 +42,6 @@ from depth_anything_3.utils.constants import (
     DEFAULT_GRADIO_DIR,
     DEFAULT_MODEL,
 )
-
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 app = typer.Typer(help="Depth Anything 3 - Video depth estimation CLI", add_completion=False)
 
@@ -380,7 +381,7 @@ def image(
         process_res_method=process_res_method,
         export_feat_layers=export_feat_layers,
         use_ray_pose=use_ray_pose,
-        reference_view_strategy=reference_view_strategy,
+        ref_view_strategy=ref_view_strategy, # Changed from reference_view_strategy to fix NameError
         conf_thresh_percentile=conf_thresh_percentile,
         num_max_points=num_max_points,
         show_cameras=show_cameras,
@@ -459,7 +460,7 @@ def images(
         process_res_method=process_res_method,
         export_feat_layers=export_feat_layers,
         use_ray_pose=use_ray_pose,
-        reference_view_strategy=reference_view_strategy,
+        ref_view_strategy=ref_view_strategy, # Changed from reference_view_strategy to fix NameError
         conf_thresh_percentile=conf_thresh_percentile,
         num_max_points=num_max_points,
         show_cameras=show_cameras,
@@ -546,7 +547,7 @@ def colmap(
         intrinsics=intrinsics,
         align_to_input_ext_scale=align_to_input_ext_scale,
         use_ray_pose=use_ray_pose,
-        reference_view_strategy=reference_view_strategy,
+        ref_view_strategy=ref_view_strategy, # Changed from reference_view_strategy to fix NameError
         conf_thresh_percentile=conf_thresh_percentile,
         num_max_points=num_max_points,
         show_cameras=show_cameras,
@@ -623,7 +624,7 @@ def video(
         process_res_method=process_res_method,
         export_feat_layers=export_feat_layers,
         use_ray_pose=use_ray_pose,
-        reference_view_strategy=reference_view_strategy,
+        ref_view_strategy=ref_view_strategy, # Changed from reference_view_strategy to fix NameError
         conf_thresh_percentile=conf_thresh_percentile,
         num_max_points=num_max_points,
         show_cameras=show_cameras,


### PR DESCRIPTION
- Comment out CUDA-only dependencies (xformers, gsplat) in pyproject.toml and requirements.txt with explanatory comments.
- Restrict requires-python to >=3.10 to resolve dependency resolution conflict with gradio>=5.
- Set KMP_DUPLICATE_LIB_OK=TRUE at the top of cli.py to prevent OpenMP crashes.
- Fix NameError in CLI by renaming reference_view_strategy to ref_view_strategy in run_inference calls.