### PR TITLE
fix: declare missing runtime dependency 'addict'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Your Name" }]
 
 dependencies = [
+    "addict",
     "pre-commit",
     "trimesh",
     "torch>=2",


### PR DESCRIPTION
## Summary

`depth_anything_3` imports `addict` at import time, but `pyproject.toml` does not declare it in `[project].dependencies`. A fresh `pip install` of the package (editable or regular) therefore fails on first import with:

```
ImportError: No module named 'addict'
```

This PR adds the one-line dependency declaration.

Fixes #86

## Test plan

- Fresh venv → `pip install -e .` → `python -c "import depth_anything_3"` succeeds (previously required a manual `pip install addict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)